### PR TITLE
Implement invalidateSurface() to free up surface memory

### DIFF
--- a/src/hardwareintegration/client/wayland-egl/qwaylandeglwindow.cpp
+++ b/src/hardwareintegration/client/wayland-egl/qwaylandeglwindow.cpp
@@ -139,6 +139,14 @@ QSurfaceFormat QWaylandEglWindow::format() const
     return m_format;
 }
 
+void QWaylandEglWindow::invalidateSurface()
+{
+    if (m_eglSurface) {
+        eglDestroySurface(m_clientBufferIntegration->eglDisplay(), m_eglSurface);
+        m_eglSurface = 0;
+    }
+}
+
 EGLSurface QWaylandEglWindow::eglSurface() const
 {
     return m_eglSurface;

--- a/src/hardwareintegration/client/wayland-egl/qwaylandeglwindow.h
+++ b/src/hardwareintegration/client/wayland-egl/qwaylandeglwindow.h
@@ -69,6 +69,8 @@ public:
 
     void bindContentFBO();
 
+    void invalidateSurface() Q_DECL_OVERRIDE;
+
 private:
     QWaylandEglClientBufferIntegration *m_clientBufferIntegration;
     struct wl_egl_window *m_waylandEglWindow;


### PR DESCRIPTION
Change-Id: I848a9f37f1b2e9616c3e5254a6329531e8eec825
Reviewed-by: Giulio Camuffo giulio.camuffo@jollamobile.com
Reviewed-by: Robin Burchell <robin+qt@viroteck.net>
