### PR TITLE
Fixes when resizing egl windows

### DIFF
--- a/src/client/qwaylandwindow.cpp
+++ b/src/client/qwaylandwindow.cpp
@@ -81,7 +81,7 @@ QWaylandWindow::QWaylandWindow(QWindow *window)
     , mRequestResizeSent(false)
     , mCanResize(true)
     , mResizeDirty(false)
-    , mResizeAfterSwap(!qEnvironmentVariableIsSet("QT_WAYLAND_RESIZE_AFTER_SWAP"))
+    , mResizeAfterSwap(qEnvironmentVariableIsSet("QT_WAYLAND_RESIZE_AFTER_SWAP"))
     , mSentInitialResize(false)
     , mMouseDevice(0)
     , mMouseSerial(0)
@@ -198,7 +198,7 @@ void QWaylandWindow::setGeometry(const QRect &rect)
     if (mWindowDecoration && window()->isVisible())
         mWindowDecoration->update();
 
-    if (mResizeAfterSwap)
+    if (mResizeAfterSwap && windowType() == Egl)
         mResizeDirty = true;
     else
         QWindowSystemInterface::handleGeometryChange(window(), geometry());

--- a/src/hardwareintegration/client/wayland-egl/qwaylandeglwindow.h
+++ b/src/hardwareintegration/client/wayland-egl/qwaylandeglwindow.h
@@ -58,7 +58,7 @@ public:
     ~QWaylandEglWindow();
     WindowType windowType() const;
 
-    void create();
+    void updateSurface(bool create);
     virtual void setGeometry(const QRect &rect);
     QRect contentsRect() const;
 

--- a/src/hardwareintegration/client/wayland-egl/qwaylandglcontext.cpp
+++ b/src/hardwareintegration/client/wayland-egl/qwaylandglcontext.cpp
@@ -114,7 +114,7 @@ bool QWaylandGLContext::makeCurrent(QPlatformSurface *surface)
 
     EGLSurface eglSurface = window->eglSurface();
     if (!eglSurface) {
-        window->create();
+        window->updateSurface(true);
         eglSurface = window->eglSurface();
     }
     if (!eglMakeCurrent(m_eglDisplay, eglSurface, eglSurface, m_context)) {


### PR DESCRIPTION
0c4f8da makes QT_WAYLAND_RESIZE_AFTER_SWAP work, not sure how we didn't see that before.
aa8d6b5 removes redundant EGLSurface allocations.
