### PR TITLE
[qtwayland] Avoid virtual calls in constructors.

### DIFF
--- a/src/client/qwaylandwindow_p.h
+++ b/src/client/qwaylandwindow_p.h
@@ -207,6 +207,7 @@ protected:
 
 private:
     bool setWindowStateInternal(Qt::WindowState flags);
+    void setGeometry_helper(const QRect &rect);
 
     void handleMouseEventWithDecoration(QWaylandInputDevice *inputDevice,
                                         ulong timestamp,


### PR DESCRIPTION
QWaylandWindow::setGeometry() is a virtual call and internally it
would call windowType() which is pure virtual, so calling it from
the constructor won't work.

Instead, set geometry explicitly from the constructor and call
setGeometry() on setVisible(true). This also merges it so we send
one expose event (with correct x/y offset) on geometry change + show.

Change-Id: I1d21664c982005c60c8d73740e43b3a463bac4a8
