### PR TITLE
MER: Destroy the wl_shell_surface resource when the wl_surface goes away

### DIFF
--- a/src/compositor/wayland_wrapper/qwlshellsurface.cpp
+++ b/src/compositor/wayland_wrapper/qwlshellsurface.cpp
@@ -103,6 +103,14 @@ ShellSurface::ShellSurface(Shell *shell, wl_client *client, uint32_t id, Surface
     , m_popupSerial()
 {
     surface->setShellSurface(this);
+    connect(surface->waylandSurface(), &QObject::destroyed, this, &ShellSurface::surfaceDestroyed);
+}
+
+void ShellSurface::surfaceDestroyed()
+{
+    m_surface = Q_NULLPTR;
+    // The spec says wl_shell_surface is destroyed when the wl_surface goes away. so do it
+    wl_resource_destroy(resource()->handle);
 }
 
 void ShellSurface::sendConfigure(uint32_t edges, int32_t width, int32_t height)

--- a/src/compositor/wayland_wrapper/qwlshellsurface_p.h
+++ b/src/compositor/wayland_wrapper/qwlshellsurface_p.h
@@ -82,7 +82,7 @@ private:
     QHash<InputDevice*, ShellSurfacePopupGrabber*> m_popupGrabber;
 };
 
-class Q_COMPOSITOR_EXPORT ShellSurface : public QtWaylandServer::wl_shell_surface
+class Q_COMPOSITOR_EXPORT ShellSurface : public QObject, public QtWaylandServer::wl_shell_surface
 {
 public:
     ShellSurface(Shell *shell, struct wl_client *client, uint32_t id, Surface *surface);
@@ -104,6 +104,8 @@ public:
     void mapPopup();
 
 private:
+    void surfaceDestroyed();
+
     Shell *m_shell;
     Surface *m_surface;
 


### PR DESCRIPTION
Does not apply to upstream, because the shell surface is deleted automatically
