### PR TITLE
Fix retrieving the selection/dnd data

### DIFF
--- a/src/client/qwaylanddataoffer_p.h
+++ b/src/client/qwaylanddataoffer_p.h
@@ -87,7 +87,7 @@ private:
 
     mutable QWaylandDataOffer *m_dataOffer;
     QWaylandDisplay *m_display;
-    mutable QHash<QString, int> m_types;
+    mutable QStringList m_types;
     mutable QHash<QString, QByteArray> m_data;
 };
 


### PR DESCRIPTION
Installing a roudtrip on the custom event queue in the wl_data_offer.offer
handler is broken because that triggers a wl_data_deveice.selection event,
which emits the QClipboard changed signal, so code listening to it may end
up trying to retrieve the clipboard data before the roundtrip ends.
Additionally, we're calling wl_data_offer.receive for each mime type, even
if then we never read from the fd, making the source client do work for no
reason. Instead, call wl_data_offer.receive retrieveData_sys, that is when
actually retreiving the data.
We don't need to install a roundtrip after that, just flushing out the
requests is enough, because we wait up to one second for the source client
to write into the fd.

Change-Id: I180779e375ebd5a22af7084458505a41107fab19
