### PR TITLE
MER: Don't attach a null buffer when hiding cover surfaces

### DIFF
--- a/src/client/qwaylandwindow.cpp
+++ b/src/client/qwaylandwindow.cpp
@@ -234,6 +234,8 @@ void QWaylandWindow::setVisible(bool visible)
         // QWaylandShmBackingStore::beginPaint().
     } else {
         QWindowSystemInterface::handleExposeEvent(window(), QRegion());
+        if (window()->flags() & Qt::CoverWindow)
+            return;
         // when flushing the event queue, it could contain a close event, in which
         // case 'this' will be deleted. When that happens, we must abort right away.
         QPointer<QWaylandWindow> deleteGuard(this);


### PR DESCRIPTION
This is an ugly hack but we don't have a better way at the moment to keep the textures of the cover windows around.
