### PR TITLE
Make sure to have valid textures

### DIFF
--- a/src/compositor/compositor_api/qwaylandquicksurface.cpp
+++ b/src/compositor/compositor_api/qwaylandquicksurface.cpp
@@ -212,12 +212,16 @@ void QWaylandQuickSurface::updateTexture()
     Q_D(QWaylandQuickSurface);
     if (d->buffer->update)
         d->buffer->createTexture();
+    foreach (QWaylandSurfaceView *view, views())
+        static_cast<QWaylandSurfaceItem *>(view)->updateTexture();
 }
 
 void QWaylandQuickSurface::invalidateTexture()
 {
     Q_D(QWaylandQuickSurface);
     d->buffer->invalidateTexture();
+    foreach (QWaylandSurfaceView *view, views())
+        static_cast<QWaylandSurfaceItem *>(view)->updateTexture();
 }
 
 bool QWaylandQuickSurface::clientRenderingEnabled() const

--- a/src/compositor/compositor_api/qwaylandsurfaceitem.cpp
+++ b/src/compositor/compositor_api/qwaylandsurfaceitem.cpp
@@ -320,13 +320,11 @@ void QWaylandSurfaceItem::updateBuffer(bool hasBuffer)
     m_newTexture = true;
 }
 
-QSGNode *QWaylandSurfaceItem::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *)
+void QWaylandSurfaceItem::updateTexture()
 {
     if (!m_provider)
         m_provider = new QWaylandSurfaceTextureProvider();
 
-    // Order here is important, as the state of visible is that of the pending
-    // buffer but will be replaced after we advance the buffer queue.
     bool mapped = surface() && surface()->isMapped();
     if (mapped)
         m_provider->t = static_cast<QWaylandQuickSurface *>(surface())->texture();
@@ -334,6 +332,11 @@ QSGNode *QWaylandSurfaceItem::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeD
     if (m_newTexture)
         emit m_provider->textureChanged();
     m_newTexture = false;
+}
+
+QSGNode *QWaylandSurfaceItem::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *)
+{
+    bool mapped = surface() && surface()->isMapped();
 
     if (!mapped || !m_provider->t || !m_paintEnabled) {
         delete oldNode;

--- a/src/compositor/compositor_api/qwaylandsurfaceitem.h
+++ b/src/compositor/compositor_api/qwaylandsurfaceitem.h
@@ -79,6 +79,7 @@ public:
     bool paintEnabled() const;
     bool touchEventsEnabled() const { return m_touchEventsEnabled; }
     bool resizeSurfaceToItem() const { return m_resizeSurfaceToItem; }
+    void updateTexture();
 
     void setTouchEventsEnabled(bool enabled);
     void setResizeSurfaceToItem(bool enabled);
@@ -123,7 +124,6 @@ protected:
 
 private:
     friend class QWaylandSurfaceNode;
-    void updateTexture();
     void init(QWaylandQuickSurface *);
 
     static QMutex *mutex;


### PR DESCRIPTION
The texture of QWaylandSurfaceItem's texture provider was updated in
QWaylandSurfaceItem::updatePaintNode(). That is fine as long as the
texture is accessed after the updatePaintNode() call, but if not we
would access an invalid texture.
That could happen when another QQuickItem subclass was accessing the
textire in its updatePaintNode(). We don't have any guarantee on the
order of the updatePaintNode() calls, so the other item could be
updated before the QWaylandSurfaceItem.

Change-Id: I7320d445c72796ce26f8d8483175a35e9c6840e7
