### PR TITLE
Don't access a dangling pointer

### DIFF
--- a/src/compositor/compositor_api/qwaylandsurface.cpp
+++ b/src/compositor/compositor_api/qwaylandsurface.cpp
@@ -92,6 +92,8 @@ QWaylandSurface::~QWaylandSurface()
 WaylandClient *QWaylandSurface::client() const
 {
     Q_D(const QWaylandSurface);
+    if (d->isDestroyed())
+        return Q_NULLPTR;
     return d->resource()->client();
 }
 


### PR DESCRIPTION
The surface's resource may have been destroyed, return a null client
in that case.

Change-Id: I3d7e0f0e94008e003e43f1987e6560dd73f5c5db
Reviewed-by: Laszlo Agocs laszlo.agocs@digia.com
