### PR TITLE
MER: Don't attach a NULL buffer when receiving a onscreen_visibility(Hid...

### DIFF
--- a/src/client/qwaylandextendedsurface.cpp
+++ b/src/client/qwaylandextendedsurface.cpp
@@ -56,6 +56,7 @@ QT_BEGIN_NAMESPACE
 QWaylandExtendedSurface::QWaylandExtendedSurface(QWaylandWindow *window)
     : QtWayland::qt_extended_surface(window->display()->windowExtension()->get_extended_surface(window->object()))
     , m_window(window)
+    , m_exposed(true)
 {
 }
 
@@ -91,7 +92,15 @@ void QWaylandExtendedSurface::setContentOrientationMask(Qt::ScreenOrientations m
 
 void QWaylandExtendedSurface::extended_surface_onscreen_visibility(int32_t visibility)
 {
-    m_window->window()->setVisibility(static_cast<QWindow::Visibility>(visibility));
+    // If visibility is Hidden we want the window to just stop rendering, not to hide.
+    // calling setVisible(false) causes a NULL buffer to be attached, and it is better
+    // to show an outdated buffer rather than random garbage from memory.
+    m_exposed = visibility != QWindow::Hidden;
+    QRegion region;
+    if (m_exposed) {
+        region = QRegion(QRect(0, 0, m_window->window()->width(), m_window->window()->height()));
+    }
+    QWindowSystemInterface::handleExposeEvent(m_window->window(), region);
 }
 
 void QWaylandExtendedSurface::extended_surface_set_generic_property(const QString &name, wl_array *value)

--- a/src/client/qwaylandextendedsurface_p.h
+++ b/src/client/qwaylandextendedsurface_p.h
@@ -66,6 +66,7 @@ public:
     void updateGenericProperty(const QString &name, const QVariant &value);
 
     Qt::WindowFlags setWindowFlags(Qt::WindowFlags flags);
+    bool isExposed() const { return m_exposed; }
 
 private:
     void extended_surface_onscreen_visibility(int32_t visibility) Q_DECL_OVERRIDE;
@@ -74,6 +75,7 @@ private:
 
     QWaylandWindow *m_window;
     QVariantMap m_properties;
+    bool m_exposed;
 };
 
 QT_END_NAMESPACE

--- a/src/client/qwaylandwlshellsurface.cpp
+++ b/src/client/qwaylandwlshellsurface.cpp
@@ -157,6 +157,11 @@ void QWaylandWlShellSurface::setTopLevel()
     set_toplevel();
 }
 
+bool QWaylandWlShellSurface::isExposed() const
+{
+    return m_extendedWindow ? m_extendedWindow->isExposed() : true;
+}
+
 void QWaylandWlShellSurface::updateTransientParent(QWindow *parent)
 {
     QWaylandWindow *parent_wayland_window = static_cast<QWaylandWindow *>(parent->handle());

--- a/src/client/qwaylandwlshellsurface_p.h
+++ b/src/client/qwaylandwlshellsurface_p.h
@@ -79,6 +79,8 @@ public:
     void setWindowFlags(Qt::WindowFlags flags) Q_DECL_OVERRIDE;
     void sendProperty(const QString &name, const QVariant &value) Q_DECL_OVERRIDE;
 
+    bool isExposed() const Q_DECL_OVERRIDE;
+
 private:
     void setMaximized() Q_DECL_OVERRIDE;
     void setFullscreen() Q_DECL_OVERRIDE;


### PR DESCRIPTION
...den) event

We're kinda cheating here, and not doing what the protocol says so I'm not sure
this would make sense upstream. However we really don't want to attach a NULL
buffer here, because we don't wait for surafces to draw a new buffer before
showing them, and we don't want random garbage either.
