### PR TITLE
Unmaplock

### DIFF
--- a/examples/qwindow-compositor/qwindowcompositor.cpp
+++ b/examples/qwindow-compositor/qwindowcompositor.cpp
@@ -95,6 +95,13 @@ public:
         }
     }
 
+    void unmapped()
+    {
+        delete shmTex;
+        shmTex = 0;
+        bufferRef = QWaylandBufferRef();
+    }
+
     QImage image() const
     {
         if (!bufferRef || !bufferRef.isShm())

--- a/src/client/qwaylandextendedsurface.cpp
+++ b/src/client/qwaylandextendedsurface.cpp
@@ -56,7 +56,6 @@ QT_BEGIN_NAMESPACE
 QWaylandExtendedSurface::QWaylandExtendedSurface(QWaylandWindow *window)
     : QtWayland::qt_extended_surface(window->display()->windowExtension()->get_extended_surface(window->object()))
     , m_window(window)
-    , m_exposed(true)
 {
 }
 
@@ -92,15 +91,7 @@ void QWaylandExtendedSurface::setContentOrientationMask(Qt::ScreenOrientations m
 
 void QWaylandExtendedSurface::extended_surface_onscreen_visibility(int32_t visibility)
 {
-    // If visibility is Hidden we want the window to just stop rendering, not to hide.
-    // calling setVisible(false) causes a NULL buffer to be attached, and it is better
-    // to show an outdated buffer rather than random garbage from memory.
-    m_exposed = visibility != QWindow::Hidden;
-    QRegion region;
-    if (m_exposed) {
-        region = QRegion(QRect(0, 0, m_window->window()->width(), m_window->window()->height()));
-    }
-    QWindowSystemInterface::handleExposeEvent(m_window->window(), region);
+    m_window->window()->setVisibility(static_cast<QWindow::Visibility>(visibility));
 }
 
 void QWaylandExtendedSurface::extended_surface_set_generic_property(const QString &name, wl_array *value)

--- a/src/client/qwaylandextendedsurface_p.h
+++ b/src/client/qwaylandextendedsurface_p.h
@@ -66,7 +66,6 @@ public:
     void updateGenericProperty(const QString &name, const QVariant &value);
 
     Qt::WindowFlags setWindowFlags(Qt::WindowFlags flags);
-    bool isExposed() const { return m_exposed; }
 
 private:
     void extended_surface_onscreen_visibility(int32_t visibility) Q_DECL_OVERRIDE;
@@ -75,7 +74,6 @@ private:
 
     QWaylandWindow *m_window;
     QVariantMap m_properties;
-    bool m_exposed;
 };
 
 QT_END_NAMESPACE

--- a/src/client/qwaylandwindow.cpp
+++ b/src/client/qwaylandwindow.cpp
@@ -243,8 +243,6 @@ void QWaylandWindow::setVisible(bool visible)
         // QWaylandShmBackingStore::beginPaint().
     } else {
         QWindowSystemInterface::handleExposeEvent(window(), QRegion());
-        if (window()->type() == Qt::CoverWindow)
-            return;
         // when flushing the event queue, it could contain a close event, in which
         // case 'this' will be deleted. When that happens, we must abort right away.
         QPointer<QWaylandWindow> deleteGuard(this);

--- a/src/client/qwaylandwlshellsurface.cpp
+++ b/src/client/qwaylandwlshellsurface.cpp
@@ -157,11 +157,6 @@ void QWaylandWlShellSurface::setTopLevel()
     set_toplevel();
 }
 
-bool QWaylandWlShellSurface::isExposed() const
-{
-    return m_extendedWindow ? m_extendedWindow->isExposed() : true;
-}
-
 void QWaylandWlShellSurface::updateTransientParent(QWindow *parent)
 {
     QWaylandWindow *parent_wayland_window = static_cast<QWaylandWindow *>(parent->handle());

--- a/src/client/qwaylandwlshellsurface_p.h
+++ b/src/client/qwaylandwlshellsurface_p.h
@@ -79,8 +79,6 @@ public:
     void setWindowFlags(Qt::WindowFlags flags) Q_DECL_OVERRIDE;
     void sendProperty(const QString &name, const QVariant &value) Q_DECL_OVERRIDE;
 
-    bool isExposed() const Q_DECL_OVERRIDE;
-
 private:
     void setMaximized() Q_DECL_OVERRIDE;
     void setFullscreen() Q_DECL_OVERRIDE;

--- a/src/compositor/compositor_api/qwaylandbufferref.h
+++ b/src/compositor/compositor_api/qwaylandbufferref.h
@@ -73,7 +73,8 @@ public:
 #ifdef QT_COMPOSITOR_WAYLAND_GL
     /**
      * There must be a GL context bound when calling this function.
-     * It is responsibility of the caller to call destroyTexture() later.
+     * The texture will be automatically destroyed when the last QWaylandBufferRef
+     * referring to the same underlying buffer will be destroyed or reset.
      */
     GLuint createTexture();
     void destroyTexture();

--- a/src/compositor/compositor_api/qwaylandsurface.cpp
+++ b/src/compositor/compositor_api/qwaylandsurface.cpp
@@ -431,4 +431,22 @@ void QWaylandSurfacePrivate::setType(QWaylandSurface::WindowType type)
     }
 }
 
+/*!
+    Constructs a QWaylandUnmapLock object.
+
+    The lock will act on the \a surface parameter, and will prevent the surface to
+    be unmapped, retaining the last valid buffer when the client attachs a NULL buffer.
+    The lock will be automatically released when deleted.
+*/
+QWaylandUnmapLock::QWaylandUnmapLock(QWaylandSurface *surface)
+                 : m_surface(surface)
+{
+    surface->handle()->addUnmapLock(this);
+}
+
+QWaylandUnmapLock::~QWaylandUnmapLock()
+{
+    m_surface->handle()->removeUnmapLock(this);
+}
+
 QT_END_NAMESPACE

--- a/src/compositor/compositor_api/qwaylandsurface.h
+++ b/src/compositor/compositor_api/qwaylandsurface.h
@@ -74,6 +74,7 @@ public:
 
 protected:
     virtual void attach(const QWaylandBufferRef &ref) = 0;
+    virtual void unmapped() = 0;
 
     friend class QtWayland::Surface;
 };
@@ -217,6 +218,16 @@ Q_SIGNALS:
 
     friend class QWaylandSurfaceView;
     friend class QWaylandSurfaceInterface;
+};
+
+class Q_COMPOSITOR_EXPORT QWaylandUnmapLock
+{
+public:
+    QWaylandUnmapLock(QWaylandSurface *surface);
+    ~QWaylandUnmapLock();
+
+private:
+    QWaylandSurface *m_surface;
 };
 
 QT_END_NAMESPACE

--- a/src/compositor/compositor_api/qwaylandsurfaceitem.cpp
+++ b/src/compositor/compositor_api/qwaylandsurfaceitem.cpp
@@ -325,9 +325,7 @@ void QWaylandSurfaceItem::updateTexture()
     if (!m_provider)
         m_provider = new QWaylandSurfaceTextureProvider();
 
-    bool mapped = surface() && surface()->isMapped();
-    if (mapped)
-        m_provider->t = static_cast<QWaylandQuickSurface *>(surface())->texture();
+    m_provider->t = static_cast<QWaylandQuickSurface *>(surface())->texture();
     m_provider->smooth = smooth();
     if (m_newTexture)
         emit m_provider->textureChanged();

--- a/src/compositor/wayland_wrapper/qwlsurface.cpp
+++ b/src/compositor/wayland_wrapper/qwlsurface.cpp
@@ -178,7 +178,7 @@ bool Surface::isYInverted() const
 
 bool Surface::mapped() const
 {
-    return m_buffer ? bool(m_buffer->waylandBufferHandle()) : false;
+    return !m_unmapLocks.isEmpty() || (m_buffer && bool(m_buffer->waylandBufferHandle()));
 }
 
 QSize Surface::size() const
@@ -283,7 +283,8 @@ void Surface::setBackBuffer(SurfaceBuffer *buffer)
 
     if (m_buffer) {
         bool valid = m_buffer->waylandBufferHandle() != 0;
-        setSize(valid ? m_buffer->size() : QSize());
+        if (valid)
+            setSize(m_buffer->size());
 
         m_damage = m_damage.intersected(QRect(QPoint(), m_size));
         emit m_waylandSurface->damaged(m_damage);
@@ -305,6 +306,20 @@ void Surface::setMapped(bool mapped)
     } else if (!mapped && m_surfaceMapped) {
         m_surfaceMapped = false;
         emit m_waylandSurface->unmapped();
+    }
+}
+
+void Surface::addUnmapLock(QWaylandUnmapLock *l)
+{
+    m_unmapLocks << l;
+}
+
+void Surface::removeUnmapLock(QWaylandUnmapLock *l)
+{
+    m_unmapLocks.removeOne(l);
+    if (!mapped() && m_attacher) {
+        setSize(QSize());
+        m_attacher->unmapped();
     }
 }
 
@@ -391,8 +406,14 @@ void Surface::surface_commit(Resource *)
         setBackBuffer(m_pending.buffer);
         m_bufferRef = QWaylandBufferRef(m_buffer);
 
-        if (m_attacher)
-            m_attacher->attach(m_bufferRef);
+        if (m_attacher) {
+            if (m_bufferRef) {
+                m_attacher->attach(m_bufferRef);
+            } else if (!mapped()) {
+                setSize(QSize());
+                m_attacher->unmapped();
+            }
+        }
         emit m_waylandSurface->configure(m_bufferRef);
     }
 

--- a/src/compositor/wayland_wrapper/qwlsurface_p.h
+++ b/src/compositor/wayland_wrapper/qwlsurface_p.h
@@ -64,6 +64,8 @@ QT_BEGIN_NAMESPACE
 
 class QTouchEvent;
 
+class QWaylandUnmapLock;
+
 namespace QtWayland {
 
 class Compositor;
@@ -132,6 +134,9 @@ public:
     void releaseSurfaces();
     void frameStarted();
 
+    void addUnmapLock(QWaylandUnmapLock *l);
+    void removeUnmapLock(QWaylandUnmapLock *l);
+
     void setMapped(bool mapped);
 
     inline bool isDestroyed() const { return m_destroyed; }
@@ -165,6 +170,7 @@ protected:
     QWaylandBufferRef m_bufferRef;
     bool m_surfaceMapped;
     QWaylandBufferAttacher *m_attacher;
+    QList<QWaylandUnmapLock *> m_unmapLocks;
 
     struct {
         SurfaceBuffer *buffer;


### PR DESCRIPTION
This reverts f4ca95e since it increased memory usage and it instead adds a way to keep ahold of the last buffer used by a surface after an attach(0) to be able to e.g. take scaled down screenshot of the original full buffer, such as https://github.com/nemomobile/lipstick/pull/256.
