### PR TITLE
Add client side support for media keys

### DIFF
--- a/src/client/qwaylandinputdevice.cpp
+++ b/src/client/qwaylandinputdevice.cpp
@@ -622,6 +622,13 @@ static const uint32_t KeyTbl[] = {
     XKB_KEY_Mode_switch,             Qt::Key_Mode_switch,
     XKB_KEY_script_switch,           Qt::Key_Mode_switch,
 
+    XKB_KEY_XF86AudioPlay,           Qt::Key_MediaTogglePlayPause, //there isn't a PlayPause keysym, however just play keys are not common
+    XKB_KEY_XF86AudioPause,          Qt::Key_MediaPause,
+    XKB_KEY_XF86AudioStop,           Qt::Key_MediaStop,
+    XKB_KEY_XF86AudioPrev,           Qt::Key_MediaPrevious,
+    XKB_KEY_XF86AudioNext,           Qt::Key_MediaNext,
+    XKB_KEY_XF86AudioRecord,         Qt::Key_MediaRecord,
+
     0,                          0
 };
 


### PR DESCRIPTION
Unfortunately we don't have a keysym in libxkbcommon for PlayPause,
we only have Play. We're going to pretend XKB_KEY_XF86AudioPlay is
really PlayPause since that is what is most common.

Change-Id: I1a75d8b5b0ea360e0f62eb7a93004ba3fababfa8
Reviewed-by: Laszlo Agocs laszlo.agocs@theqtcompany.com
Reviewed-by: Pier Luigi Fiorini pierluigi.fiorini@gmail.com
