### PR TITLE
Fix possible race condition leading to a dead lock

### DIFF
--- a/examples/server-buffer/client/main.cpp
+++ b/examples/server-buffer/client/main.cpp
@@ -95,7 +95,6 @@ public:
 
         QWaylandDisplay *wayland_display = wayland_integration->display();
         struct ::wl_registry *registry = wl_display_get_registry(wayland_display->wl_display());
-        wl_proxy_set_queue(reinterpret_cast<struct wl_proxy *>(registry), wayland_display->wl_event_queue());
         QtWayland::wl_registry::init(registry);
     }
 

--- a/src/client/qwaylanddisplay.cpp
+++ b/src/client/qwaylanddisplay.cpp
@@ -150,12 +150,7 @@ QWaylandDisplay::QWaylandDisplay(QWaylandIntegration *waylandIntegration)
     mEventThreadObject->displayConnect();
     mDisplay = mEventThreadObject->display(); //blocks until display is available
 
-    //Create a new even queue for the QtGui thread
-    mEventQueue = wl_display_create_queue(mDisplay);
-
     struct ::wl_registry *registry = wl_display_get_registry(mDisplay);
-    wl_proxy_set_queue((struct wl_proxy *)registry, mEventQueue);
-
     init(registry);
 
     connect(mEventThreadObject, SIGNAL(newEventsRead()), this, SLOT(flushRequests()));
@@ -178,7 +173,7 @@ QWaylandDisplay::~QWaylandDisplay(void)
 
 void QWaylandDisplay::flushRequests()
 {
-    if (wl_display_dispatch_queue_pending(mDisplay, mEventQueue) < 0) {
+    if (wl_display_dispatch_pending(mDisplay) < 0) {
         mEventThreadObject->checkError();
         exitWithError();
     }
@@ -189,7 +184,7 @@ void QWaylandDisplay::flushRequests()
 
 void QWaylandDisplay::blockingReadEvents()
 {
-    if (wl_display_dispatch_queue(mDisplay, mEventQueue) < 0) {
+    if (wl_display_dispatch(mDisplay) < 0) {
         mEventThreadObject->checkError();
         exitWithError();
     }
@@ -336,19 +331,7 @@ static const struct wl_callback_listener sync_listener = {
 
 void QWaylandDisplay::forceRoundTrip()
 {
-    // wl_display_roundtrip() works on the main queue only,
-    // but we use a separate one, so basically reimplement it here
-    int ret = 0;
-    bool done = false;
-    wl_callback *callback = wl_display_sync(mDisplay);
-    wl_proxy_set_queue((struct wl_proxy *)callback, mEventQueue);
-    wl_callback_add_listener(callback, &sync_listener, &done);
-    flushRequests();
-    while (!done && ret >= 0)
-        ret = wl_display_dispatch_queue(mDisplay, mEventQueue);
-
-    if (ret == -1 && !done)
-        wl_callback_destroy(callback);
+    wl_display_roundtrip(mDisplay);
 }
 
 QtWayland::xdg_shell *QWaylandDisplay::shellXdg()

--- a/src/client/qwaylanddisplay_p.h
+++ b/src/client/qwaylanddisplay_p.h
@@ -112,7 +112,6 @@ public:
     void setCursor(struct wl_buffer *buffer, struct wl_cursor_image *image);
 
     struct wl_display *wl_display() const { return mDisplay; }
-    struct wl_event_queue *wl_event_queue() const { return mEventQueue; }
     struct ::wl_registry *wl_registry() { return object(); }
 
     const struct wl_compositor *wl_compositor() const { return mCompositor.object(); }
@@ -173,7 +172,6 @@ private:
     };
 
     struct wl_display *mDisplay;
-    struct wl_event_queue *mEventQueue;
     QtWayland::wl_compositor mCompositor;
     struct wl_shm *mShm;
     QThread *mEventThread;

--- a/src/client/qwaylandeventthread.cpp
+++ b/src/client/qwaylandeventthread.cpp
@@ -86,14 +86,10 @@ void QWaylandEventThread::checkError() const
 
 void QWaylandEventThread::readWaylandEvents()
 {
-    if (wl_display_dispatch(m_display) < 0) {
-        checkError();
-        m_readNotifier->setEnabled(false);
-        emit fatalError();
-        return;
+    if (wl_display_prepare_read(m_display) == 0) {
+        wl_display_read_events(m_display);
+        emit newEventsRead();
     }
-
-    emit newEventsRead();
 }
 
 void QWaylandEventThread::waylandDisplayConnect()


### PR DESCRIPTION
It is a bit dangerous to call wl_display_dispatch() in the event thread,
since it may race with the dispatch called e.g. in QWaylandDisplay's
blockingReadEvents() and lead to a dead lock. Instead, use wl_display_prepare_read()
and wl_display_read_events() in the event thread, which doesn't block, and only
dispatch in QWaylandDisplay.
