### PR TITLE
Fix private object leak in surface op/interface classes

### DIFF
--- a/src/compositor/compositor_api/qwaylandsurfaceinterface.cpp
+++ b/src/compositor/compositor_api/qwaylandsurfaceinterface.cpp
@@ -60,6 +60,7 @@ QWaylandSurfaceInterface::QWaylandSurfaceInterface(QWaylandSurface *surface)
 QWaylandSurfaceInterface::~QWaylandSurfaceInterface()
 {
     d->surface->removeInterface(this);
+    delete d;
 }
 
 QWaylandSurface *QWaylandSurfaceInterface::surface() const
@@ -94,6 +95,11 @@ QWaylandSurfaceOp::QWaylandSurfaceOp(int t)
                  : d(new Private)
 {
     d->type = t;
+}
+
+QWaylandSurfaceOp::~QWaylandSurfaceOp()
+{
+    delete d;
 }
 
 int QWaylandSurfaceOp::type() const

--- a/src/compositor/compositor_api/qwaylandsurfaceinterface.h
+++ b/src/compositor/compositor_api/qwaylandsurfaceinterface.h
@@ -62,6 +62,8 @@ public:
     };
 
     QWaylandSurfaceOp(int t);
+    virtual ~QWaylandSurfaceOp();
+
     int type() const;
 
 private:


### PR DESCRIPTION
Change-Id: I7ad508cb07a73d6699e9d2742ea029409f498a87
Reviewed-by: Giulio Camuffo giulio.camuffo@jollamobile.com
