### PR TITLE
Make sure to always dispatch all events

### DIFF
--- a/src/client/qwaylandeventthread.cpp
+++ b/src/client/qwaylandeventthread.cpp
@@ -88,8 +88,8 @@ void QWaylandEventThread::readWaylandEvents()
 {
     if (wl_display_prepare_read(m_display) == 0) {
         wl_display_read_events(m_display);
-        emit newEventsRead();
     }
+    emit newEventsRead();
 }
 
 void QWaylandEventThread::waylandDisplayConnect()


### PR DESCRIPTION
wl_display_prepare_read returns -1 if there already are some events
in the queue ready to be dispatched. That can happen if some other thread
reads the events from the fd, so make sure to dispatch the pending events.
