### PR TITLE
[qtwayland] Reset transientParent when parent is destroyed.

### DIFF
--- a/src/compositor/wayland_wrapper/qwlsurface.cpp
+++ b/src/compositor/wayland_wrapper/qwlsurface.cpp
@@ -364,6 +364,14 @@ void Surface::surface_destroy_resource(Resource *)
         m_extendedSurface = 0;
     }
 
+    if (transientParent()) {
+        foreach (Surface *surface, compositor()->surfaces()) {
+            if (surface->transientParent() == this) {
+                surface->setTransientParent(0);
+            }
+        }
+    }
+
     m_destroyed = true;
     m_waylandSurface->destroy();
     emit m_waylandSurface->surfaceDestroyed();


### PR DESCRIPTION
If a transient parent of a surface is destroyed before the surface
itself, reset all references to that parent surface.
