### PR TITLE
Prevent QWaylandQuickSurface from holding onto multiple buffers indef…

### DIFF
--- a/rpm/qtwayland.spec
+++ b/rpm/qtwayland.spec
@@ -11,7 +11,7 @@ Source100:	precheckin.sh
 BuildRequires:  pkgconfig(Qt5Core) >= 5.2.1
 BuildRequires:  pkgconfig(Qt5PlatformSupport) >= 5.2.1
 BuildRequires:  pkgconfig(Qt5Qml) >= 5.2.1
-BuildRequires:  pkgconfig(Qt5Quick) >= 5.2.1
+BuildRequires:  pkgconfig(Qt5Quick) >= 5.2.1+git37
 BuildRequires:  pkgconfig(Qt5DBus) >= 5.2.1
 BuildRequires:  pkgconfig(wayland-server) >= 1.2.0
 BuildRequires:  pkgconfig(wayland-client) >= 1.2.0

--- a/src/compositor/compositor_api/qwaylandsurfaceitem.cpp
+++ b/src/compositor/compositor_api/qwaylandsurfaceitem.cpp
@@ -339,12 +339,17 @@ void QWaylandSurfaceItem::updateBuffer(bool hasBuffer)
 
 void QWaylandSurfaceItem::updateTexture()
 {
+    updateTexture(false);
+}
+
+void QWaylandSurfaceItem::updateTexture(bool changed)
+{
     if (!m_provider)
         m_provider = new QWaylandSurfaceTextureProvider();
 
     m_provider->t = static_cast<QWaylandQuickSurface *>(surface())->texture();
     m_provider->smooth = smooth();
-    if (m_newTexture)
+    if (m_newTexture || changed)
         emit m_provider->textureChanged();
     m_newTexture = false;
 }

--- a/src/compositor/compositor_api/qwaylandsurfaceitem.h
+++ b/src/compositor/compositor_api/qwaylandsurfaceitem.h
@@ -124,7 +124,9 @@ protected:
 
 private:
     friend class QWaylandSurfaceNode;
+    friend class QWaylandQuickSurface;
     void init(QWaylandQuickSurface *);
+    void updateTexture(bool changed);
 
     static QMutex *mutex;
 


### PR DESCRIPTION
…initely.

With a queue of just two buffers BufferAttacher can end up holding
references to both after the renderer is stopped starving the client
application and causing it to block in the glSwapBuffers until the
renderer restarts or the surface is destroyed.  Release the current
buffer to the client when the renderer is stopped so it can continue.

Change-Id: Ica0e13ef78f7e6058e273c26b517a88d07f958c7
