### PR TITLE
update keymap right away when no key is currently pressed

### DIFF
--- a/src/compositor/wayland_wrapper/qwlkeyboard.cpp
+++ b/src/compositor/wayland_wrapper/qwlkeyboard.cpp
@@ -144,7 +144,15 @@ void Keyboard::setFocus(Surface* surface)
 void Keyboard::setKeymap(const QWaylandKeymap &keymap)
 {
     m_keymap = keymap;
-    m_pendingKeymap = true;
+
+    // If there is no key currently pressed, update right away the keymap
+    // Otherwise, delay the update when keys are released
+    // see http://lists.freedesktop.org/archives/wayland-devel/2013-October/011395.html
+    if (m_keys.isEmpty()) {
+        updateKeymap();
+    } else {
+        m_pendingKeymap = true;
+    }
 }
 
 void Keyboard::focusDestroyed(void *data)
@@ -219,6 +227,10 @@ void Keyboard::keyEvent(uint code, uint32_t state)
             }
         }
     }
+
+    // If keys are no longer pressed, update the keymap
+    if (m_pendingKeymap && m_keys.isEmpty())
+        updateKeymap();
 }
 
 void Keyboard::sendKeyEvent(uint code, uint32_t state)
@@ -267,11 +279,6 @@ void Keyboard::updateModifierState(uint code, uint32_t state)
 
 void Keyboard::updateKeymap()
 {
-    // There must be no keys pressed when changing the keymap,
-    // see http://lists.freedesktop.org/archives/wayland-devel/2013-October/011395.html
-    if (!m_pendingKeymap || !m_keys.isEmpty())
-        return;
-
     m_pendingKeymap = false;
 #ifndef QT_NO_WAYLAND_XKB
     createXKBKeymap();


### PR DESCRIPTION
Keymap update was only performed when a key was pressed. A key press right after a keymap update was pretty long.
Keymap may therefore be updated if no key is currently pressed. It avoids waiting for the next key press.
It must also be set when last key was released and do no need to wait for the next key press.

Change-Id: I9646a02f3112c8beb0f1cf90139e2b69af55a9b0
Reviewed-by: Giulio Camuffo giulio.camuffo@jollamobile.com
