### PR TITLE
Don't invalidate textures when the scene graph is stopped.

### DIFF
--- a/src/compositor/compositor_api/qwaylandquicksurface.cpp
+++ b/src/compositor/compositor_api/qwaylandquicksurface.cpp
@@ -169,7 +169,6 @@ QWaylandQuickSurface::QWaylandQuickSurface(wl_client *client, quint32 id, int ve
     QQuickWindow *window = static_cast<QQuickWindow *>(compositor->window());
     connect(window, &QQuickWindow::beforeSynchronizing, this, &QWaylandQuickSurface::updateTexture, Qt::DirectConnection);
     connect(window, &QQuickWindow::sceneGraphInvalidated, this, &QWaylandQuickSurface::invalidateTexture, Qt::DirectConnection);
-    connect(window, &QQuickWindow::sceneGraphAboutToStop, this, &QWaylandQuickSurface::invalidateTexture, Qt::DirectConnection);
     connect(this, &QWaylandSurface::windowPropertyChanged, d->windowPropertyMap, &QQmlPropertyMap::insert);
     connect(d->windowPropertyMap, &QQmlPropertyMap::valueChanged, this, &QWaylandSurface::setWindowProperty);
 


### PR DESCRIPTION
The texture often represents the last reference to the last buffer of
a destroyed surface and invalidating releases that reference which
shortcuts any attempt to keep the buffer alive with QWaylandUnmapLock.

Change-Id: I4641a87a32f8639c3ffb6c3b5dafd21c77bbb2c1
Reviewed-by: Giulio Camuffo giulio.camuffo@jollamobile.com
