### PR TITLE
Allow KEY_MEDIA to be used as headset key.

### DIFF
--- a/src/shared/qwaylandxkb.cpp
+++ b/src/shared/qwaylandxkb.cpp
@@ -134,6 +134,7 @@ static const uint32_t KeyTbl[] = {
     XKB_KEY_XF86AudioMute,           Qt::Key_VolumeMute,
 
     XKB_KEY_XF86Phone,               Qt::Key_ToggleCallHangup,
+    XKB_KEY_XF86AudioMedia,          Qt::Key_ToggleCallHangup,
 
     0,                          0
 };


### PR DESCRIPTION
[keys] Allow KEY_MEDIA to be used as headset key. Contributes JB#33503

On android devices headset is passing KEY_MEDIA as headset key, which
needs also to be mapped to the functionality.

Signed-off-by: Marko Saukko marko.saukko@jolla.com
